### PR TITLE
Gemspec update

### DIFF
--- a/KSEAWeb.gemspec
+++ b/KSEAWeb.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r!^(assets|_layouts|_includes|_sass|LICENSE|README)!i) }
 
-  spec.add_runtime_dependency "jekyll", "~> 4.0"
+  spec.add_runtime_dependency "jekyll", ">= 3.8"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 12.0"
 end


### PR DESCRIPTION
For Android, Jekyll 3.8 version
For general, bundler 2 also works